### PR TITLE
Remove LSP init options from lean.nvim

### DIFF
--- a/lua/lazy-plugins.lua
+++ b/lua/lazy-plugins.lua
@@ -381,9 +381,6 @@ require('lazy').setup({
 
     -- see details below for full configuration options
     opts = {
-      lsp = {
-        init_options = { editDelay = 0 },
-      },
       mappings = true,
       abbreviations = {
         -- Enable expanding of unicode abbreviations?


### PR DESCRIPTION
This is essentially already the default, and avoids a deprecation warning.

https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/neovim.20.28error.20message.2Fprocessing.20message.29